### PR TITLE
fix: Fix install/quickstart commands

### DIFF
--- a/content/docs/inspector/index.mdx
+++ b/content/docs/inspector/index.mdx
@@ -47,19 +47,19 @@ You can start the Muppet MCP Inspector using the `muppet-kit` command line tool.
 <Tabs groupId='package-manager' persist items={['npm', 'pnpm', 'yarn', 'bun']} label='Start the Inspector'>
 
 ```bash tab="npm"
-npm muppet-kit inspector
+npx muppet-kit inspector
 ```
 
 ```bash tab="pnpm"
-pnpm muppet-kit inspector
+pnpx muppet-kit inspector
 ```
 
 ```bash tab="yarn"
-yarn muppet-kit inspector
+yarn dlx muppet-kit inspector
 ```
 
 ```bash tab="bun"
-bun muppet-kit inspector
+bunx muppet-kit inspector
 ```
 
 </Tabs>
@@ -69,19 +69,19 @@ You can also use the Inspector as a standalone package if you prefer
 <Tabs groupId='package-manager' persist items={['npm', 'pnpm', 'yarn', 'bun']} label='Start the Inspector'>
 
 ```bash tab="npm"
-npm @muppet-kit/inspector
+npx @muppet-kit/inspector
 ```
 
 ```bash tab="pnpm"
-pnpm @muppet-kit/inspector
+pnpx @muppet-kit/inspector
 ```
 
 ```bash tab="yarn"
-yarn @muppet-kit/inspector
+yarn dlx @muppet-kit/inspector
 ```
 
 ```bash tab="bun"
-bun @muppet-kit/inspector
+bunx @muppet-kit/inspector
 ```
 
 </Tabs>


### PR DESCRIPTION
`npm` definitely does not have a `muppet-kit` or `@muppet-kit/inspector` command so those all fail :grin

I think the intention was to use the `-x` version of these commands to download and run quickly. At least that's what I did and it worked flawlessly so updating the docs accordingly.